### PR TITLE
Update URL property in version file

### DIFF
--- a/GameData/ContractPacks/RAD/RAD.version
+++ b/GameData/ContractPacks/RAD/RAD.version
@@ -1,6 +1,6 @@
 {
 	"NAME":"Contract Pack: Research Advancement Division",
-	"URL":"https://github.com/Morphisor244/Research-Advancement-Division/blob/main/GameData/ContractPacks/RAD.version",
+	"URL":"https://github.com/Morphisor244/Research-Advancement-Division/blob/main/GameData/ContractPacks/RAD/RAD.version",
 	"DOWNLOAD":"https://github.com/Morphisor244/Research-Advancement-Division/releases",
 	"VERSION":
 	{


### PR DESCRIPTION
Hi @Morphisor244,

The version file moved to a new location in 68c4349fadb1e8fd56860b3298abf7c5989fcd0e, so the current `URL` property is now a 404.
This pull request updates it.

Cheers!